### PR TITLE
Negative redshift

### DIFF
--- a/background.py
+++ b/background.py
@@ -12,6 +12,8 @@ def E_z(z, ΩM=constants['matter-density'], ΩDE=constants['DE-density'],
     """
     Method to compute the adimensional Hubble rate in the w0waCDm cosmology
     """
+    if z < 0:
+        raise TypeError("Enter a non-negative redshift.")
     ΩK = 1-ΩM-ΩDE-ΩR
     return np.sqrt(ΩM*(1+z)**3+ΩR*(1+z)**4+ΩDE*(1+z)**(3*(1+w0+wa))*np.exp(-3*wa*z/(1+z))+ΩK*(1+z)**2)
 
@@ -21,6 +23,8 @@ def H_z(z, H0=constants['Hubble0'], ΩM=constants['matter-density'],
     """
     Method to compute the Hubble rate in the w0waCDm cosmology
     """
+    if z < 0:
+        raise TypeError("Enter a non-negative redshift.")
     return H0*E_z(z, ΩM, ΩDE, ΩR, w0, wa)
 
 def comoving_distance(z, H0=constants['Hubble0'], ΩM=constants['matter-density'], 
@@ -29,6 +33,8 @@ def comoving_distance(z, H0=constants['Hubble0'], ΩM=constants['matter-density'
     """
     Method to compute the comoving distance
     """
+    if z < 0:
+        raise TypeError("Enter a non-negative redshift.")
     integrand = lambda x: 1/E_z(x, ΩM, ΩDE, ΩR, w0, wa)
     if isinstance(z, float) or isinstance(z, int):
         result, _ = integrate.quad(integrand, 0, z)
@@ -45,6 +51,8 @@ def transverse_comoving_distance(z, H0=constants['Hubble0'], ΩM=constants['matt
     """
     Compute the transverse comoving distance
     """
+    if z < 0:
+        raise TypeError("Enter a non-negative redshift.")
     D_c = comoving_distance(z, H0, ΩM, ΩDE, ΩR, w0, wa)
     ΩK = 1 - ΩM - ΩDE - ΩR
     c0 = constants['speed-of-light']

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -12,8 +12,7 @@ class ComovingDistanceTest(unittest.TestCase):
         self.assertAlmostEqual(result, 3411.733, delta=0.1)
     def test_redshift_negative(self):
         data = -1.
-        result = bg.comoving_distance(data)
-        self.assertEqual(result, "Booh, no negative redshifts!")
+        self.assertRaises(TypeError, bg.comoving_distance, data)
     #def test_redshift_string(self):
     #    data = "1."
     #    results = bg.comoving_distance(data)

--- a/tests/test_transverse_cdistance.py
+++ b/tests/test_transverse_cdistance.py
@@ -12,5 +12,4 @@ class Transverse_CDistance(unittest.TestCase):
         self.assertAlmostEqual(result, 3411.733, delta=0.1)
     def test_cdistance_negative(self):
         data = -1.
-        result = bg.transverse_comoving_distance(data)
-        self.assertEqual(result, "Booh, no negative redshifts!")
+        self.assertRaises(TypeError, bg.transverse_comoving_distance, data)


### PR DESCRIPTION
The calculator now throws a `TypeError` if negative redshifts are input. I have also updated the tests to reflect this.